### PR TITLE
Updates to make Reach functions make more sense

### DIFF
--- a/R/auth_reach.R
+++ b/R/auth_reach.R
@@ -27,7 +27,7 @@ auth_reach <- function (
 
     )
 
-    access_token <<- VERB(
+    access_token <- VERB(
 
         "POST",
         url = "https://api.reach.vote/oauth/token",
@@ -37,5 +37,7 @@ auth_reach <- function (
     ) %>%
     content() %>%
     pluck(., 1)
+
+    return(access_token)
     
 }

--- a/R/get_external_id_types.R
+++ b/R/get_external_id_types.R
@@ -1,6 +1,8 @@
 #' @title get_external_id_types
 #'
 #' @description Function to retrieve external ID types for Reach API
+#' 
+#' @param access_token Access token to interact with a given Reach campaign via API
 #'
 #' @return A dataframe of external ID types
 #'
@@ -9,9 +11,12 @@
 #' @import purrr
 #'
 #' @export
-get_external_id_types <- function() {
-
-    auth_reach()
+get_external_id_types <- function(
+    access_token
+) {
+    if(is.null(access_token)) {
+        access_token <- auth_reach()
+    }
 
     external_id_types <<- VERB(
         "GET",

--- a/R/get_tags.R
+++ b/R/get_tags.R
@@ -1,6 +1,8 @@
 #' @title get_tags
 #'
 #' @description Function to retrieve tags from Reach API
+#' 
+#' @param access_token Access token to interact with a given Reach campaign via API
 #'
 #' @return A dataframe of all tags in the Reach campaign for which you are authenticated
 #'
@@ -9,9 +11,12 @@
 #'
 #' @export
 
-get_tags <- function() {
-
-    auth_reach()
+get_tags <- function(
+    access_token
+) {
+    if(is.null(access_token)) {
+        access_token <- auth_reach()
+    }
 
     tags <<- VERB(
         "GET",

--- a/R/import_tag.R
+++ b/R/import_tag.R
@@ -21,7 +21,7 @@ import_tag <- function(
 ) {
 
     if(is.null(access_token)) {
-        auth_reach()
+       access_token <- auth_reach()
     }
 
     datareturn <- VERB(

--- a/R/import_tag.R
+++ b/R/import_tag.R
@@ -4,6 +4,7 @@
 #'
 #' @param tag_id ID of the tag you want to apply
 #' @param file_url URL of the hosted CSV file
+#' @param access_token Access token to interact with a given Reach campaign via API
 #'
 #' @return A message indicating the import has started
 #'

--- a/R/import_tag.R
+++ b/R/import_tag.R
@@ -16,10 +16,13 @@
 
 import_tag <- function(
     tag_id,
-    file_url
+    file_url,
+    access_token
 ) {
 
-    auth_reach()
+    if(is.null(access_token)) {
+        auth_reach()
+    }
 
     datareturn <- VERB(
         "POST",
@@ -33,7 +36,7 @@ import_tag <- function(
 
     name <- paste0("status_url_", tag_id)
 
-    status_url <<- glue("https://api.reach.vote/api/v1/imports/tags/{datareturn$data$id}")
+    status_url <- glue("https://api.reach.vote/api/v1/imports/tags/{datareturn$data$id}")
 
     assign(name, status_url, envir = .GlobalEnv)
 

--- a/R/import_tag_status.R
+++ b/R/import_tag_status.R
@@ -3,6 +3,7 @@
 #' @description Function to retrieve tag import job status from Reach API
 #'
 #' @param status_url URL for tag import job status
+#' @param access_token Access token to interact with a given Reach campaign via API
 #'
 #' @return A message indicating the import job's status
 #'
@@ -13,10 +14,12 @@
 #' @export
 
 import_tag_status <- function(
-    status_url
+    status_url,
+    access_token
 ) {
-
-    auth_reach()
+    if(is.null(access_token)) {
+        access_token <- auth_reach()
+    }
 
     VERB(
         "GET",


### PR DESCRIPTION
Mostly covered in #2. 

1st improvement is removing superassigment from the auth_reach function.

2nd improvement so far is adding a parameter for access_token in each function, and handling to fall back on using `auth_reach()` if no access_token provided

3rd improvement is to work on webhook handling - @lkesich I haven't really used webhooks before so may call on your experience to talk about what this might look like. I'll do some research in the meantime tho!

4th improvement will be proposing and then implementing better handling for the `status_url` that's used for tag imports